### PR TITLE
Add the function to be auto scalable

### DIFF
--- a/simulation/config/raft/node-4.textpb
+++ b/simulation/config/raft/node-4.textpb
@@ -1,0 +1,9 @@
+replication_mode: RAFT
+raft_config: {
+  id: "node-4:7476"
+  peers: "node-0:7476"
+  peers: "node-1:7476"
+  peers: "node-2:7476"
+  peers: "node-3:7476"
+  heartbeat_interval: "10s"
+}

--- a/simulation/raft.yaml
+++ b/simulation/raft.yaml
@@ -51,3 +51,21 @@ services:
     - CONFIG=/config/node-3.textpb
     cpus: 0.50
     mem_limit: 2G
+
+  node-4:
+    depends_on:
+    - node-0
+    - node-1
+    - node-2
+    - node-3
+    image: pubsub
+    ports:
+    - "7480:7476"
+    volumes:
+    - type: bind
+      source: ./config/raft
+      target: /config
+    environment:
+    - CONFIG=/config/node-4.textpb
+    cpus: 0.50
+    mem_limit: 2G


### PR DESCRIPTION
After the change, raft can add new nodes when others are already set up. (only new nodes need to know all the previous nodes while the previous node don't need to preconfigured with the new node)